### PR TITLE
uses lines method rather than splitting on \n

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "pwfuzz-rs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "rand",

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn main() {
     let mut words = read_to_string(cli.wordlist_file)
         .unwrap_or_else(|_| "".to_string())
         .trim()
-        .split('\n')
+        .lines()
         .map(|s| s.to_string())
         .collect::<Vec<String>>();
 


### PR DESCRIPTION
Think this handles file endings better. And probably Windows line endings?