### PR TITLE
handles error for if wordlist file doesn't exist

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -102,12 +102,14 @@ fn load_rules<P: AsRef<Path>>(path: P) -> Result<Vec<Rule>, String> {
 fn main() -> Result<(), String> {
     let cli = Cli::parse();
 
-    let mut words = read_to_string(cli.wordlist_file)
-        .unwrap_or_else(|_| "".to_string())
-        .trim()
-        .lines()
-        .map(|s| s.to_string())
-        .collect::<Vec<String>>();
+    let mut words = match read_to_string(cli.wordlist_file) {
+        Ok(words) => words
+            .trim()
+            .lines()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>(),
+        Err(e) => return Err(e.to_string()),
+    };
 
     match load_rules(cli.rules_file) {
         Ok(rules) => {


### PR DESCRIPTION
This PR attempts to improve the handling of errors when pwfuzz-rs attempts to read a user-given word list file. It does this by replacing the rather blunt `.unwrap_or_else(|_| "".to_string())` line in the `main` function. 

Instead we use a `match` statement to handle both the `Ok(words)` possibility and the `Err(e)` possibility.